### PR TITLE
update install instructions for OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _site
 Gemfile.lock
 .DS_Store
+vendor

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 Future devmission.org
 
 ## Development
-1. Install Jekyll [on OS X](http://jekyll.tips/jekyll-casts/install-jekyll-on-os-x/) or [on Windows](http://jekyll.tips/jekyll-casts/install-jekyll-on-windows/)
+### OS X
+1. `brew instll ruby`
+1. `sudo gem install bundler`
+1. `mkdir vendor && bundler install --path vendor`
+1. `bundle exec jekyll --serve`
+1. Any changes should be in a new branch and then submitted for review as a pull request
+### Windows
+1. [Install Jekyll](http://jekyll.tips/jekyll-casts/install-jekyll-on-windows/)
 1. Clone repository and open the directory in the Terminal
 1. `gem install jekyll bundler` and `bundle install` to install dependencies
 1. `jekyll serve` to start the server and open http://127.0.0.1:4000/devmission.org/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Future devmission.org
 
 ## Development
 ### OS X
+1. If you don't have homebrew installed, [install homebrew](https://brew.sh/)
 1. `brew instll ruby`
 1. `sudo gem install bundler`
 1. `mkdir vendor && bundler install --path vendor`


### PR DESCRIPTION
I was getting a lot of permission issues when trying to install the ruby dependencies for getting the website up and running. I've been able to get things setup and running now in a way that requires minimal usage of sudo. I've codified the install steps I followed in some new read me instructions. This should allow folks install local-only versions of jekyll and all of our dependencies without needing sudo.

The only things that still need sudo are installing the correct version of ruby and installing the bundler gem which is needed to boot strap the whole process.